### PR TITLE
Bump version number for new release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ILog2"
 uuid = "2cd5bd5f-40a1-5050-9e10-fc8cdb6109f5"
 authors = ["John Lapeyre <jlapeyre@users.noreply.github.com>"]
-version = "0.2.4"
+version = "1.0.0"
 
 [compat]
 Aqua = ">= 0.8"


### PR DESCRIPTION
No reason to maintain dev-only version numbers. Releasing 1.0 This includes bug fixes, and new tests, updated docs.