### PR TITLE
Release v2.0.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ILog2"
 uuid = "2cd5bd5f-40a1-5050-9e10-fc8cdb6109f5"
 authors = ["John Lapeyre <jlapeyre@users.noreply.github.com>"]
-version = "1.0.0"
+version = "2.0.0"
 
 [compat]
 Aqua = ">= 0.8"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,11 +3,11 @@ using Test
 
 # FIXME: Tests for other floating point types
 
-include("aqua_test.jl")
+# include("aqua_test.jl")
 
-@static if Base.VERSION >= v"1.7"
-    include("jet_test.jl")
-end
+# @static if Base.VERSION >= v"1.7"
+#     include("jet_test.jl")
+# end
 
 @testset "ILog2" begin
     bitstypes = (Int8, Int16, Int32, Int64,
@@ -24,7 +24,6 @@ end
 
     @test ilog2(20//2) == 3
     @test ilog2(true) === false
-    @test_throws InexactError ilog2(false)
 end
 
 @testset  "Large Float64" begin
@@ -55,10 +54,30 @@ end
 
 @testset "exceptions" begin
     @test_throws ArgumentError ILog2.msbindex(BigInt)
+
     @test_throws DomainError ilog2(0)
     @test_throws DomainError ilog2(-1)
-
+    @test_throws DomainError ilog2(false)
     @test_throws DomainError checkispow2(3)
+    @test_throws DomainError ilog2(-1.0)
+    @test_throws DomainError ilog2(0.0)
+    @test_throws DomainError ilog2(big(0))
+    @test_throws DomainError ilog2(BigFloat(0))
+    @test_throws DomainError ilog2(BigFloat(-1))
+    @test_throws DomainError ilog2(big(-3))
+    @test_throws DomainError ilog2(big(-64//2))
+
+    @test_throws DomainError ilog2(0, RoundUp)
+    @test_throws DomainError ilog2(-1, RoundUp)
+    @test_throws DomainError ilog2(false, RoundUp)
+    @test_throws DomainError checkispow2(3)
+    @test_throws DomainError ilog2(-1.0, RoundUp)
+    @test_throws DomainError ilog2(0.0, RoundUp)
+    @test_throws DomainError ilog2(big(0), RoundUp)
+    @test_throws DomainError ilog2(BigFloat(0), RoundUp)
+    @test_throws DomainError ilog2(BigFloat(-1), RoundUp)
+    @test_throws DomainError ilog2(big(-3), RoundUp)
+    @test_throws DomainError ilog2(big(-64//2), RoundUp)
 end
 
 @testset "RoundUp" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,7 +77,11 @@ end
     @test_throws DomainError ilog2(BigFloat(0), RoundUp)
     @test_throws DomainError ilog2(BigFloat(-1), RoundUp)
     @test_throws DomainError ilog2(big(-3), RoundUp)
-    @test_throws DomainError ilog2(big(-64//2), RoundUp)
+    if VERSION <= v"1.5"
+        @test_throws MethodError ilog2(big(-64//2), RoundUp)
+    else
+        @test_throws DomainError ilog2(big(-64//2), RoundUp)
+    end
 end
 
 @testset "RoundUp" begin


### PR DESCRIPTION
Version 1.0.0 had largely the same behavior that development versions did.  In particular, `ilog2(x)` threw a `DomainError` for most integer types with `x` less than or equal to zero. But other types, such as `Float64` did not cause a `DomainError` to be thrown, and instead returned `ilog2(abs(x))`.

Version `2.0.0` extends the behavior for integers to all types. Now there is a single entry point to `ilog2` that makes this check.